### PR TITLE
Sync residual_draws and predicted_draws with tidybayes 3.0 API

### DIFF
--- a/R/tidy-posterior-BART.R
+++ b/R/tidy-posterior-BART.R
@@ -94,6 +94,7 @@ fitted_draws_BART <- function(model, newdata = NULL, value = ".value", ..., incl
 #' @param include_newdata Should the newdata be included in the tibble?
 #' @param include_fitted Should the posterior fitted values be included in the tibble?
 #' @param include_sigsqs Should the posterior sigma-squared draw be included?
+#' @param ... Arguments to pass to \code{predict} (e.g. \code{BART:::predict.wbart}).
 #'
 #' @return A tidy data frame (tibble) with predicted values.
 #'
@@ -325,7 +326,7 @@ residual_draws.wbart <- function(object, newdata, value = ".residual", ..., ndra
 #' @return Tibble with residuals.
 #' @export
 #'
-residual_draws.pbart <- function(object, newdata, value = ".residual", ..., n = NULL, include_newdata = TRUE, include_sigsqs = FALSE) {
+residual_draws.pbart <- function(object, newdata, value = ".residual", ..., ndraws = NULL, include_newdata = TRUE, include_sigsqs = FALSE) {
   if (missing(newdata)) {
     newdata <- NULL
   }

--- a/man/predicted_draws.bartMachine.Rd
+++ b/man/predicted_draws.bartMachine.Rd
@@ -5,26 +5,26 @@
 \title{Get predict draws from posterior of \code{bartMachine} model}
 \usage{
 \method{predicted_draws}{bartMachine}(
-  model,
+  object,
   newdata,
-  prediction = ".prediction",
+  value = ".prediction",
   ...,
-  n = NULL,
+  ndraws = NULL,
   include_newdata = TRUE,
   include_fitted = FALSE,
   include_sigsqs = FALSE
 )
 }
 \arguments{
-\item{model}{A \code{bartMachine} model.}
+\item{object}{A \code{bartMachine} model.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, most model types will generate predictions from the data used to fit the model.}
 
-\item{prediction}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
+\item{value}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
 
 \item{...}{Not currently in use.}
 
-\item{n}{Not currently implemented.}
+\item{ndraws}{Not currently implemented.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/man/predicted_draws.wbart.Rd
+++ b/man/predicted_draws.wbart.Rd
@@ -5,26 +5,26 @@
 \title{Get predict draws from posterior of \code{wbart} model}
 \usage{
 \method{predicted_draws}{wbart}(
-  model,
+  object,
   newdata,
-  prediction = ".prediction",
+  value = ".prediction",
   ...,
-  n = NULL,
+  ndraws = NULL,
   include_newdata = TRUE,
   include_fitted = FALSE,
   include_sigsqs = FALSE
 )
 }
 \arguments{
-\item{model}{A \code{wbart} model.}
+\item{object}{A \code{wbart} model.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, most model types will generate predictions from the data used to fit the model.}
 
-\item{prediction}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
+\item{value}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
 
 \item{...}{Use to specify random number generator, default is \code{rng=stats::rnorm}.}
 
-\item{n}{Not currently implemented.}
+\item{ndraws}{Not currently implemented.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/man/predicted_draws_BART.Rd
+++ b/man/predicted_draws_BART.Rd
@@ -5,9 +5,10 @@
 \title{Get predict draws from posterior of \code{BART}-package models}
 \usage{
 predicted_draws_BART(
-  model,
+  object,
   newdata = NULL,
-  prediction = ".prediction",
+  value = ".prediction",
+  ...,
   rng = stats::rnorm,
   include_newdata = TRUE,
   include_fitted = FALSE,
@@ -15,11 +16,11 @@ predicted_draws_BART(
 )
 }
 \arguments{
-\item{model}{A \code{BART}-package model.}
+\item{object}{A \code{BART}-package model.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, most model types will generate predictions from the data used to fit the model.}
 
-\item{prediction}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
+\item{value}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
 
 \item{rng}{Random number generator function. Default is \code{rnorm} for models with Gaussian errors.}
 

--- a/man/predicted_draws_BART.Rd
+++ b/man/predicted_draws_BART.Rd
@@ -22,6 +22,8 @@ predicted_draws_BART(
 
 \item{value}{The name of the output column for \code{predicted_draws}; default \code{".prediction"}.}
 
+\item{...}{Arguments to pass to \code{predict} (e.g. \code{BART:::predict.wbart}).}
+
 \item{rng}{Random number generator function. Default is \code{rnorm} for models with Gaussian errors.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}

--- a/man/residual_draws.bartMachine.Rd
+++ b/man/residual_draws.bartMachine.Rd
@@ -5,25 +5,25 @@
 \title{Get residual draw for \code{bartMachine} model}
 \usage{
 \method{residual_draws}{bartMachine}(
-  model,
+  object,
   newdata,
-  residual = ".residual",
+  value = ".residual",
   ...,
-  n = NULL,
+  ndraws = NULL,
   include_newdata = TRUE,
   include_sigsqs = FALSE
 )
 }
 \arguments{
-\item{model}{\code{bartMachine} model.}
+\item{object}{\code{bartMachine} model.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, original data used to fit the model.}
 
-\item{residual}{Name of the output column for residual_draws; default is \code{.residual}.}
+\item{value}{Name of the output column for residual_draws; default is \code{.residual}.}
 
 \item{...}{Additional arguments passed to the underlying prediction method for the type of model given.}
 
-\item{n}{Not currently implemented.}
+\item{ndraws}{Not currently implemented.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/man/residual_draws.pbart.Rd
+++ b/man/residual_draws.pbart.Rd
@@ -5,9 +5,9 @@
 \title{Get residual draw for \code{pbart} model}
 \usage{
 \method{residual_draws}{pbart}(
-  model,
+  object,
   newdata,
-  residual = ".residual",
+  value = ".residual",
   ...,
   n = NULL,
   include_newdata = TRUE,
@@ -15,15 +15,13 @@
 )
 }
 \arguments{
-\item{model}{\code{wbart} model.}
+\item{object}{\code{wbart} model.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, original data used to fit the model.}
 
-\item{residual}{Name of the output column for residual_draws; default is \code{.residual}.}
+\item{value}{Name of the output column for residual_draws; default is \code{.residual}.}
 
 \item{...}{Additional arguments passed to the underlying prediction method for the type of model given.}
-
-\item{n}{Not currently implemented.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/man/residual_draws.pbart.Rd
+++ b/man/residual_draws.pbart.Rd
@@ -9,7 +9,7 @@
   newdata,
   value = ".residual",
   ...,
-  n = NULL,
+  ndraws = NULL,
   include_newdata = TRUE,
   include_sigsqs = FALSE
 )
@@ -22,6 +22,8 @@
 \item{value}{Name of the output column for residual_draws; default is \code{.residual}.}
 
 \item{...}{Additional arguments passed to the underlying prediction method for the type of model given.}
+
+\item{ndraws}{Not currently implemented.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/man/residual_draws.wbart.Rd
+++ b/man/residual_draws.wbart.Rd
@@ -5,25 +5,25 @@
 \title{Get residual draw for \code{wbart} model}
 \usage{
 \method{residual_draws}{wbart}(
-  model,
+  object,
   newdata,
-  residual = ".residual",
+  value = ".residual",
   ...,
-  n = NULL,
+  ndraws = NULL,
   include_newdata = TRUE,
   include_sigsqs = FALSE
 )
 }
 \arguments{
-\item{model}{\code{wbart} model.}
+\item{object}{\code{wbart} model.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, original data used to fit the model.}
 
-\item{residual}{Name of the output column for residual_draws; default is \code{.residual}.}
+\item{value}{Name of the output column for residual_draws; default is \code{.residual}.}
 
 \item{...}{Additional arguments passed to the underlying prediction method for the type of model given.}
 
-\item{n}{Not currently implemented.}
+\item{ndraws}{Not currently implemented.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/man/residual_draws_BART.Rd
+++ b/man/residual_draws_BART.Rd
@@ -5,22 +5,22 @@
 \title{Get residual draw for BART model}
 \usage{
 residual_draws_BART(
-  model,
+  object,
   response,
   newdata = NULL,
-  residual = ".residual",
+  value = ".residual",
   include_newdata = TRUE,
   include_sigsqs = FALSE
 )
 }
 \arguments{
-\item{model}{model from \code{BART} package.}
+\item{object}{model from \code{BART} package.}
 
 \item{response}{Original response vector.}
 
 \item{newdata}{Data frame to generate predictions from. If omitted, original data used to fit the model.}
 
-\item{residual}{Name of the output column for residual_draws; default is \code{.residual}.}
+\item{value}{Name of the output column for residual_draws; default is \code{.residual}.}
 
 \item{include_newdata}{Should the newdata be included in the tibble?}
 

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -27,7 +27,7 @@ check_df <- check_matrix %>%
 
 test_that("Predicted values calculated correctly", {
   td_pd <- predicted_draws(bartmodel1,
-    newdata = pdata, include_newdata = FALSE, prediction = "pred",
+    newdata = pdata, include_newdata = FALSE, value = "pred",
     rng = function(n, mean, ...) {
       mean + 0.1
     }

--- a/tests/testthat/test-residuals.R
+++ b/tests/testthat/test-residuals.R
@@ -19,7 +19,7 @@ check_df <- check_matrix %>%
   mutate(.row = as.integer(.row))
 
 test_that("Residual values calculated correctly", {
-  td_fd <- residual_draws(bartmodel1, newdata = suhillsim1$data, response = suhillsim1$data$y, include_newdata = FALSE, residual = "resid")
+  td_fd <- residual_draws(bartmodel1, newdata = suhillsim1$data, response = suhillsim1$data$y, include_newdata = FALSE, value = "resid")
   comp_df <- td_fd %>% full_join(check_df, by = c(".row", ".draw"))
   expect_equal(comp_df$resid, comp_df$resid_check)
 })


### PR DESCRIPTION
Hi! tidytreatment looks like a great package; it's really awesome to see people building on the tidybayes API :)

Some slightly unfortunate news: I am about to submit a new version of tidybayes to CRAN that changes some parts of the tidybayes API that will cause some test failures on the existing version of tidytreatment on CRAN. The good news is this PR will fix those failures.

The changes in tidybayes that are relevant here are:
- The first argument for all the `XXX_draws()` functions (fitted, predicted, etc) is now `object` instead of `model`, as these typically call down to posterior_predict / posterior_epred / posterior_linpred, and those functions also use `object`. In some corner cases this was causing problems (specifically, rstanarm's `posterior_predict` has an `m` argument that could not be passed to it via `add_predicted_draws()` due to partial argument matching thinking the user was specifying `model`). This PR renames `model` to `object` in your implementations of `residual_draws` and `predicted_draws`. It does not change `fitted_draws` for reasons outlined below.
- The arguments that name the output column of the various functions (e.g. `value = ".value"`, `residual = ".residual"`, `prediction = ".prediction"`) are now all called `value` (the default column name is still the same for each function though --- e.g. the default is `value = ".residual"` for residual_draws). In retrospect having this argument have a different name for each function was confusing. This PR renames the relevant columns to `value` in your implementations of `residual_draws` and `predicted_draws`. You shouldn't have to worry if you have existing users using the old column names; the `tidybayes` generic for those functions automatically passes through the desired column name to the `value` argument and gives the user a deprecation warning if they use the old argument name.
- The `n` argument is renamed to `ndraws`. This is not a huge change since you don't implement it. This makes it more consistent with naming schemes in the new posterior package, and also prevents corner cases where `n` is partially matched to the `newdata` argument (really, partial argument matching is just a terrible feature in R).

Your test suite passes under this PR if either the CRAN version of tidybayes or the github version is installed.

There's another big change I did not try to address in this PR as it does not currently cause any test failures and I'm not sure how you'd want to handle it: as of the next version, `tidybayes::fitted_draws()` will be deprecated. At least, the default implementation is --- after much experience teaching folks how to use the package, I've come to the realization that "fitted" is a terrible name for the function that only serves to confuse students. Users are now directed to use either `epred_draws()` (which gives draws from the expected value of the posterior predictive; after `rstantools::posterior_epred()`) or `linpred_draws()` (which gives draws from the linear predictor; after `rstantools::posterior_linpred()`). I'd suggest a similar change here, but of course you're welcome to ignore my advice :). Tidybayes will continue to export the `fitted_draws()` generic and the deprecation warning is only hit in `fitted_draws.default()`, so if you choose to keep using the `fitted_draws` name everything should continue to work and your users should not see a deprecation warning.

I will be making a submission to CRAN soon (probably later this week). If you're able to submit a new version before I do that would be awesome --- it should save you an angry email from CRAN telling you to update the package due to test failures. Sorry to be the bearer of such news, but I hope having a PR attach to the request will make it easier to deal with :). Happy to try to help / answer questions as needed.