### PR TITLE
Just call `readr::read_table()`

### DIFF
--- a/R/tree-extract-BART.R
+++ b/R/tree-extract-BART.R
@@ -45,7 +45,7 @@ posterior_trees_BART <- function(model, label_digits = 2) {
   out$n_var <- as.integer(fline[3])
 
   out$trees <- suppressWarnings(
-    readr::read_table2(
+    readr::read_table(
       file = model$treedraws$trees,
       col_names = c("node", "var", "cut", "leaf"),
       col_types =


### PR DESCRIPTION
The `read_table2()` function will be removed in the next release of readr. It has been deprecated for over 4 years, since readr v2.0.0 (2021-07-20). Since that time, it has just been aliased to `read_table()` anyway.

This is part of a bigger effort to advance a bunch of deprecation processes that started 4+ years ago: https://github.com/tidyverse/readr/issues/1600. I released readr v2.1.6 on 2025-11-14 and have no immediate plans for another release. I just wanted to advanced these deprecations right away, to give downstream dependencies plenty of time to adjust.

I am also sending an email to the maintainer listed in DESCRIPTION.